### PR TITLE
chore: drop support for Node.js < 16.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
BREAKING CHANGE: Node.js 16.x or newer required